### PR TITLE
Add metadata field to `create_supabase_user`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following is auto-generated off of comments in the `supabase_test_helpers.sq
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [tests.create_supabase_user(identifier text, email text, phone text)](#testscreate_supabase_useridentifier-text-email-text-phone-text)
+- [tests.create_supabase_user(identifier text, email text, phone text, metadata jsonb)](#testscreate_supabase_useridentifier-text-email-text-phone-text-metadata-jsonb)
 - [tests.get_supabase_user(identifier text)](#testsget_supabase_useridentifier-text)
 - [tests.get_supabase_uid(identifier text)](#testsget_supabase_uididentifier-text)
 - [tests.authenticate_as(identifier text)](#testsauthenticate_asidentifier-text)
@@ -33,7 +33,7 @@ The following is auto-generated off of comments in the `supabase_test_helpers.sq
 
 <!-- include: supabase_test_helpers.sql -->
 
-### tests.create_supabase_user(identifier text, email text, phone text)
+### tests.create_supabase_user(identifier text, email text, phone text, metadata jsonb)
 
 Creates a new user in the `auth.users` table.
 You can recall a user's info by using `tests.get_supabase_user(identifier text)`.
@@ -42,6 +42,7 @@ Parameters:
 - `identifier` - A unique identifier for the user. We recommend you keep it memorable like "test_owner" or "test_member"
 - `email` - (Optional) The email address of the user
 - `phone` - (Optional) The phone number of the user
+- `metadata` - (Optional) Additional metadata to be added to the user
 
 Returns:
 - `user_id` - The UUID of the user in the `auth.users` table
@@ -50,6 +51,7 @@ Example:
 ```sql
   SELECT tests.create_supabase_user('test_owner');
   SELECT tests.create_supabase_user('test_member', 'member@test.com', '555-555-5555');
+  SELECT tests.create_supabase_user('test_member', 'member@test.com', '555-555-5555', '{"key": "value"}'::jsonb);
 ```
 
 ### tests.get_supabase_user(identifier text)

--- a/supabase_test_helpers.sql
+++ b/supabase_test_helpers.sql
@@ -250,7 +250,7 @@ $$ LANGUAGE sql;
 BEGIN;
 
     select plan(7);
-    select function_returns('tests', 'create_supabase_user', Array['text', 'text', 'text'], 'uuid');
+    select function_returns('tests', 'create_supabase_user', Array['text', 'text', 'text', 'jsonb'], 'uuid');
     select function_returns('tests', 'get_supabase_uid', Array['text'], 'uuid');
     select function_returns('tests', 'get_supabase_user', Array['text'], 'json');
     select function_returns('tests', 'authenticate_as', Array['text'], 'void');

--- a/supabase_test_helpers.sql
+++ b/supabase_test_helpers.sql
@@ -77,7 +77,7 @@ AS $$
     DECLARE
         supabase_user json;
     BEGIN
-        SELECT json_build_object('id', id, 'email', email, 'phone', phone) into supabase_user FROM auth.users WHERE raw_user_meta_data ->> 'test_identifier' = identifier limit 1;
+        SELECT json_build_object('id', id, 'email', email, 'phone', phone, 'raw_user_meta_data', raw_user_meta_data) into supabase_user FROM auth.users WHERE raw_user_meta_data ->> 'test_identifier' = identifier limit 1;
         if supabase_user is null OR supabase_user -> 'id' IS NULL then
             RAISE EXCEPTION 'User with identifier % not found', identifier;
         end if;

--- a/supabase_test_helpers.sql
+++ b/supabase_test_helpers.sql
@@ -22,6 +22,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA tests GRANT EXECUTE ON FUNCTIONS TO anon, aut
     * - `identifier` - A unique identifier for the user. We recommend you keep it memorable like "test_owner" or "test_member"
     * - `email` - (Optional) The email address of the user
     * - `phone` - (Optional) The phone number of the user
+    * - `metadata` - (Optional) Additional metadata to be added to the user
     *
     * Returns:
     * - `user_id` - The UUID of the user in the `auth.users` table
@@ -30,9 +31,10 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA tests GRANT EXECUTE ON FUNCTIONS TO anon, aut
     * ```sql
     *   SELECT tests.create_supabase_user('test_owner');
     *   SELECT tests.create_supabase_user('test_member', 'member@test.com', '555-555-5555');
+    *   SELECT tests.create_supabase_user('test_member', 'member@test.com', '555-555-5555', '{"key": "value"}'::jsonb);
     * ```
  */
-CREATE OR REPLACE FUNCTION tests.create_supabase_user(identifier text, email text default null, phone text default null)
+CREATE OR REPLACE FUNCTION tests.create_supabase_user(identifier text, email text default null, phone text default null, metadata jsonb default null)
 RETURNS uuid
     SECURITY DEFINER
     SET search_path = auth, pg_temp
@@ -44,7 +46,7 @@ BEGIN
     -- create the user
     user_id := extensions.uuid_generate_v4();
     INSERT INTO auth.users (id, email, phone, raw_user_meta_data)
-    VALUES (user_id, coalesce(email, concat(user_id, '@test.com')), phone, json_build_object('test_identifier', identifier))
+    VALUES (user_id, coalesce(email, concat(user_id, '@test.com')), phone, jsonb_build_object('test_identifier', identifier) || coalesce(metadata, '{}'::jsonb))
     RETURNING id INTO user_id;
 
     RETURN user_id;

--- a/tests/02-create-supabase-users.sql
+++ b/tests/02-create-supabase-users.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
-select plan(14);
+select plan(15);
 
 -- test creating a user
 select tests.create_supabase_user('testuser');
 select tests.create_supabase_user('testuser2', 'testuser2@test.com');
 select tests.create_supabase_user('testuser3', null, '555-555-5555');
-select tests.create_supabase_user('testuser4', null, null, '{"has": "json"}'::jsonb);
+select tests.create_supabase_user('testuser4', null, null, '{"has": "or has not"}'::jsonb);
 
 select is((select count(*)::integer from auth.users), 4, 'create_supabase_user should have created 4 users');
 
@@ -14,7 +14,7 @@ select is((select tests.get_supabase_uid('testuser')), (select id from auth.user
 select is((select (tests.get_supabase_user('testuser') ->> 'id')::uuid), (select id from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser'), 'get_supabase_user should return a user id');
 select is((select tests.get_supabase_user('testuser2') ->> 'email'), (select email::text from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser2'), 'get_supabase_user should return a user email');
 select is((select tests.get_supabase_user('testuser3') ->> 'phone'), (select phone::text from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser3'), 'get_supabase_user should return a user phone');
-select is((select tests.get_supabase_user('testuser4') ->> 'raw_user_metadata' ->> 'has'), (select raw_user_metadata ->> 'has' from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser4'), 'get_supabase_user should return custom metadata');
+select is((select tests.get_supabase_user('testuser4') -> 'raw_user_meta_data' ->> 'has'), (select raw_user_meta_data ->> 'has' from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser4'), 'get_supabase_user should return custom metadata');
 select throws_ok($$ select tests.get_supabase_user('testuser5') $$, 'User with identifier testuser5 not found');
 
 -- should not mess with transactions current role

--- a/tests/02-create-supabase-users.sql
+++ b/tests/02-create-supabase-users.sql
@@ -6,14 +6,16 @@ select plan(14);
 select tests.create_supabase_user('testuser');
 select tests.create_supabase_user('testuser2', 'testuser2@test.com');
 select tests.create_supabase_user('testuser3', null, '555-555-5555');
+select tests.create_supabase_user('testuser4', null, null, '{"has": "json"}'::jsonb);
 
-select is((select count(*)::integer from auth.users), 3, 'create_supabase_user should have created 3 users');
+select is((select count(*)::integer from auth.users), 4, 'create_supabase_user should have created 4 users');
 
 select is((select tests.get_supabase_uid('testuser')), (select id from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser'), 'get_supabase_uid should return a user');
 select is((select (tests.get_supabase_user('testuser') ->> 'id')::uuid), (select id from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser'), 'get_supabase_user should return a user id');
 select is((select tests.get_supabase_user('testuser2') ->> 'email'), (select email::text from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser2'), 'get_supabase_user should return a user email');
 select is((select tests.get_supabase_user('testuser3') ->> 'phone'), (select phone::text from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser3'), 'get_supabase_user should return a user phone');
-select throws_ok($$ select tests.get_supabase_user('testuser4') $$, 'User with identifier testuser4 not found');
+select is((select tests.get_supabase_user('testuser3') ->> 'raw_user_metadata' ->> 'has'), (select raw_user_metadata ->> 'has' from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser4'), 'get_supabase_user should return custom metadata');
+select throws_ok($$ select tests.get_supabase_user('testuser5') $$, 'User with identifier testuser5 not found');
 
 -- should not mess with transactions current role
 set role anon;

--- a/tests/02-create-supabase-users.sql
+++ b/tests/02-create-supabase-users.sql
@@ -14,7 +14,7 @@ select is((select tests.get_supabase_uid('testuser')), (select id from auth.user
 select is((select (tests.get_supabase_user('testuser') ->> 'id')::uuid), (select id from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser'), 'get_supabase_user should return a user id');
 select is((select tests.get_supabase_user('testuser2') ->> 'email'), (select email::text from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser2'), 'get_supabase_user should return a user email');
 select is((select tests.get_supabase_user('testuser3') ->> 'phone'), (select phone::text from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser3'), 'get_supabase_user should return a user phone');
-select is((select tests.get_supabase_user('testuser3') ->> 'raw_user_metadata' ->> 'has'), (select raw_user_metadata ->> 'has' from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser4'), 'get_supabase_user should return custom metadata');
+select is((select tests.get_supabase_user('testuser4') ->> 'raw_user_metadata' ->> 'has'), (select raw_user_metadata ->> 'has' from auth.users where raw_user_meta_data ->> 'test_identifier' = 'testuser4'), 'get_supabase_user should return custom metadata');
 select throws_ok($$ select tests.get_supabase_user('testuser5') $$, 'User with identifier testuser5 not found');
 
 -- should not mess with transactions current role


### PR DESCRIPTION
A small PR to add an optional `metadata` field to the `create_supabase_user` function. We have a trigger on the `auth.users` table to insert into another table, and it's useful to be able to wrap `create_supabase_user` with something like `create_platform_user` to populate extra metadata for said trigger to use.

This PR just uses Postgres' JSONb concatenation to allow additional metadata to be passed to the function.