### PR TITLE
add service_role usage and privileges

### DIFF
--- a/supabase_test_helpers.sql
+++ b/supabase_test_helpers.sql
@@ -5,12 +5,12 @@ create extension if not exists pgtap with schema extensions;
 -- separate from any application data
 CREATE SCHEMA IF NOT EXISTS tests;
 
--- anon and authenticated should have access to tests schema
-GRANT USAGE ON SCHEMA tests TO anon, authenticated;
+-- anon, authenticated, and service_role should have access to tests schema
+GRANT USAGE ON SCHEMA tests TO anon, authenticated, service_role;
 -- Don't allow public to execute any functions in the tests schema
 ALTER DEFAULT PRIVILEGES IN SCHEMA tests REVOKE EXECUTE ON FUNCTIONS FROM public;
--- Grant execute to anon and authenticated for testing purposes
-ALTER DEFAULT PRIVILEGES IN SCHEMA tests GRANT EXECUTE ON FUNCTIONS TO anon, authenticated;
+-- Grant execute to anon, authenticated, and service_role for testing purposes
+ALTER DEFAULT PRIVILEGES IN SCHEMA tests GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
 
 /**
     * ### tests.create_supabase_user(identifier text, email text, phone text)

--- a/supabase_test_helpers_pglet.sql
+++ b/supabase_test_helpers_pglet.sql
@@ -9,12 +9,12 @@ $_pg_tle_$
 -- separate from any application data
 CREATE SCHEMA IF NOT EXISTS tests;
 
--- anon and authenticated should have access to tests schema
-GRANT USAGE ON SCHEMA tests TO anon, authenticated;
+-- anon, authenticated, and service_role should have access to tests schema
+GRANT USAGE ON SCHEMA tests TO anon, authenticated, service_role;
 -- Don't allow public to execute any functions in the tests schema
 ALTER DEFAULT PRIVILEGES IN SCHEMA tests REVOKE EXECUTE ON FUNCTIONS FROM public;
--- Grant execute to anon and authenticated for testing purposes
-ALTER DEFAULT PRIVILEGES IN SCHEMA tests GRANT EXECUTE ON FUNCTIONS TO anon, authenticated;
+-- Grant execute to anon, authenticated, and service_role for testing purposes
+ALTER DEFAULT PRIVILEGES IN SCHEMA tests GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
 
 /**
     * ### tests.create_supabase_user(identifier text, email text, phone text)


### PR DESCRIPTION
If I have a function that should only be executable be the `service_role`, I can't use the test helpers to get the `uid` of the users and have to use workarounds.

Currently the `service_role` is not included in the GRANT USAGE/EXECUTE for the test schema/helpers which leads to manually including it in my tests.

This PR includes the `service_role` in the GRANT USAGE/EXECUTE so the following is possible.

```sql
select set_config('role', 'service_role', true);
SELECT tests.create_supabase_user('test_user'); -- works now
```

Without this PR, above fails with `permission denied for schema tests`
